### PR TITLE
[WIP] Optimise no-op builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ tracing-error = "0.2.0"
 tracing-core = "0.1.21"
 color-eyre = {version = "0.6.0", features = ["color-spantrace"]}
 serde_json = "1.0.79"
-execution_layer = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
-types = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
-task_executor = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
-sensitive_url = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
-eth2 = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
+execution_layer = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }
+types = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }
+task_executor = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }
+sensitive_url = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }
+eth2 = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }
 exit-future = "0.2.0"
 parking_lot = "0.12.0"
 hex = "0.4.3"
@@ -34,10 +34,11 @@ ethereum-consensus = {git = "https://github.com/ralexstokes/ethereum-consensus",
 ssz-rs = {git = "https://github.com/ralexstokes/ssz-rs", rev = "cb08f1" }
 async-trait = "0.1.51"
 rand = "0.8.5"
+futures = "0.3.24"
 
 [patch.crates-io]
-eth2_serde_utils = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
-eth2_ssz_types = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
-tree_hash = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
-eth2_ssz = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
-eth2_hashing = { git = "https://github.com/realbigsean/lighthouse", rev = "d35934df2c7cdcb692e6f1c09d9f387f5d9e8972" }
+eth2_serde_utils = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }
+eth2_ssz_types = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }
+tree_hash = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }
+eth2_ssz = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }
+eth2_hashing = { git = "https://github.com/michaelsproul/lighthouse", rev = "1ace774dc8105425c14050863ab73267cfc39ede" }

--- a/src/noop_builder.rs
+++ b/src/noop_builder.rs
@@ -16,7 +16,9 @@ use parking_lot::RwLock;
 use ssz_rs::Merkleized;
 use std::collections::HashMap;
 use std::sync::Arc;
-use types::{ChainSpec, EthSpec, ExecutionBlockHash};
+use types::{Address, ChainSpec, EthSpec};
+
+const DEFAULT_GAS_LIMIT: u64 = 30_000_000;
 
 #[derive(Clone)]
 pub struct NoOpBuilder<E: EthSpec> {
@@ -26,10 +28,21 @@ pub struct NoOpBuilder<E: EthSpec> {
     payload_cache: Arc<PayloadCache<E>>,
     val_registration_cache: Arc<RwLock<HashMap<BlsPublicKey, SignedValidatorRegistration>>>,
     builder_sk: SecretKey,
+    config: NoOpConfig,
+}
+
+#[derive(Clone)]
+pub struct NoOpConfig {
+    pub default_fee_recipient: Option<Address>,
 }
 
 impl<E: EthSpec> NoOpBuilder<E> {
-    pub fn new(beacon_client: BeaconNodeHttpClient, spec: ChainSpec, context: Context) -> Self {
+    pub fn new(
+        beacon_client: BeaconNodeHttpClient,
+        spec: ChainSpec,
+        context: Context,
+        config: NoOpConfig,
+    ) -> Self {
         let sk = SecretKey::random(&mut rand::thread_rng()).unwrap();
         Self {
             beacon_client,
@@ -38,6 +51,7 @@ impl<E: EthSpec> NoOpBuilder<E> {
             val_registration_cache: Arc::new(RwLock::new(HashMap::new())),
             payload_cache: Arc::new(PayloadCache::default()),
             builder_sk: sk,
+            config,
         }
     }
 
@@ -74,28 +88,46 @@ impl<E: EthSpec> BlindedBlockProvider for NoOpBuilder<E> {
         &self,
         bid_request: &BidRequest,
     ) -> Result<SignedBuilderBid, BlindedBlockProviderError> {
-        let signed_cached_data = self
+        let (fee_recipient, gas_limit) = self
             .val_registration_cache
             .read()
             .get(&bid_request.public_key)
-            .ok_or_else(|| convert_err("missing registration"))?
-            .clone();
-        let cached_data = signed_cached_data.message;
-        let fee_recipient = from_ssz_rs(&cached_data.fee_recipient)?;
+            .map_or_else(
+                || {
+                    self.config
+                        .default_fee_recipient
+                        .map(|fee_recipient| (fee_recipient, DEFAULT_GAS_LIMIT))
+                        .ok_or_else(|| {
+                            BlindedBlockProviderError::Custom(format!(
+                                "missing registration and no default fee recipient set"
+                            ))
+                        })
+                },
+                |registration| {
+                    let fee_recipient = from_ssz_rs(&registration.message.fee_recipient)?;
+                    let gas_limit = registration.message.gas_limit;
+                    Ok((fee_recipient, gas_limit))
+                },
+            )?;
 
-        let (payload_attributes, forkchoice_update_params, block_number) =
+        // FIXME(sproul): this takes 2s+ on Goerli
+        //
+        // really we just need:
+        // - prev_randao (from head state)
+        // - block_number (parent block + 1)
+        tracing::info!("requesting parameters from BN");
+        let (payload_attributes, _, block_number) =
             get_params::<E>(&self.beacon_client, bid_request, fee_recipient, &self.spec).await?;
+        tracing::info!("obtained parameters from BN");
 
         let payload = FullPayload {
             execution_payload: ExecutionPayload {
-                parent_hash: forkchoice_update_params
-                    .head_hash
-                    .unwrap_or(ExecutionBlockHash::zero()),
+                parent_hash: from_ssz_rs(&bid_request.parent_hash)?,
                 timestamp: payload_attributes.timestamp,
                 fee_recipient: fee_recipient,
                 prev_randao: payload_attributes.prev_randao,
                 block_number,
-                gas_limit: cached_data.gas_limit,
+                gas_limit,
                 ..Default::default()
             },
         };


### PR DESCRIPTION
This PR updates the `empty-payload` builder so that it can build payloads _without_ receiving a prior validator registration.

For [`blockdreamer`](https://github.com/michaelsproul/blockdreamer) I need a builder that will return a dummy payload at every slot as quickly as possible. Bypassing the registration step is essential, as blockdreamer never has the ability to sign as the true proposer.

I've added a flag `--default-fee-recipient` which specifies a fee recipient to be used in when the registration is missing.