### PR TITLE
Trick Prysm's empty payload checks

### DIFF
--- a/src/noop_builder.rs
+++ b/src/noop_builder.rs
@@ -18,7 +18,7 @@ use parking_lot::RwLock;
 use ssz_rs::Merkleized;
 use std::collections::HashMap;
 use std::sync::Arc;
-use types::{Address, ChainSpec, EthSpec};
+use types::{Address, ChainSpec, EthSpec, VariableList};
 
 const DEFAULT_GAS_LIMIT: u64 = 30_000_000;
 
@@ -175,6 +175,7 @@ impl<E: EthSpec> BlindedBlockProvider for NoOpBuilder<E> {
                 prev_randao,
                 block_number,
                 gas_limit,
+                transactions: VariableList::new(vec![VariableList::new(vec![0]).unwrap()]).unwrap(),
                 ..Default::default()
             },
         };

--- a/src/noop_builder.rs
+++ b/src/noop_builder.rs
@@ -185,7 +185,7 @@ impl<E: EthSpec> BlindedBlockProvider for NoOpBuilder<E> {
 
         let mut message = BuilderBid {
             header: to_ssz_rs(&header)?,
-            value: ssz_rs::U256::default(),
+            value: ssz_rs::U256::from(1u64),
             public_key: self.builder_sk.public_key(),
         };
 


### PR DESCRIPTION
These are some hacks I'm using with blockprint at the moment to bypass Prysm's health checks on the builder payload:

- 1 wei bid rather than 0
- not-quite-empty transactions list (single invalid transaction of `0u8`)